### PR TITLE
Build confirmatory analysis pipeline and GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,49 +14,25 @@ This repository contains Jupyter notebooks and helper files for **processing and
 
 ---
 
-### `data_analysis/`
+### `analysis_pipeline/`
 
-- **pupilsize_exploration.ipynb**  
-  Aggregates normalized pupil sizes from the fixation files by image category and outputs statistical summaries and boxplots.  
-  _(Visualization only, no files written)._
+Modular Python package that powers the confirmatory analysis workflow:
 
----
+- **data_loading.py** – builds participant-level metric tables from the processed fixation CSVs and merges them with label metadata.
+- **metrics.py** – reusable metric computation helpers (fixation counts, scanpath length, pupil metrics, etc.).
+- **hierarchy.py** – aggregates metrics hierarchically (all images → single labels → label combinations) with baseline deltas normalised by the 49 participants.
+- **clustering.py** – PCA + k-means helpers for discovering label clusters in the metric space.
+- **statistics.py** – confirmatory statistical tests (ANOVA, Kruskal-Wallis, pairwise post-hoc comparisons, effect sizes).
+- **visualization.py** – Plotly-based plotting utilities for metric deltas, distributions, and clustering views.
+- **gui.py** – Streamlit application that exposes the full exploratory-to-confirmatory workflow interactively.
 
-### `preprocessing/`
+### Example notebooks
 
-- **data_processed.ipynb**
+- **notebooks/confirmatory_analysis_example.ipynb** – step-by-step demonstration of loading metrics, building hierarchical summaries, running statistical tests, and exploring clustering.
 
-  - Reads raw CSV files
-  - Converts timestamps to milliseconds
-  - Filters and interpolates gaze data
-  - Normalizes pupil size
-  - Detects fixations using the I-DT algorithm
-  - Saves results:
-    - Cleaned files as `*_processed.csv`
-    - Fixations under `processed/fixations/` as `*_fixations.csv`
+### Legacy notebooks
 
-- **names_fixed.ipynb** – Scans the raw directory for files matching `ProbandXX_idYY`, renames them to `PXXX_idYY_category` while avoiding number collisions. Trailing underscore files are removed.
-- **renaming.ipynb** – Currently empty; reserved for future renaming utilities.
-
----
-
-### `visualization/`
-
-- **heatmaps.ipynb**  
-  Builds heatmaps from fixation files (`x`, `y` columns), smoothed with a Gaussian kernel.
-
-  - Outputs to `processed/heatmaps/`
-  - Flattens all heatmaps, reduces them via PCA, and performs hierarchical clustering to visualize clusters and their average heatmaps.
-
-- **scanpaths.ipynb**  
-  Loads each `*_fixations.csv`, sorts fixations by start time, and plots the temporal sequence of gaze positions.
-
-  - Outputs to `processed/scanpaths/` as `*_scanpath.png`
-
-- **heatmaps/** – Directory of generated heatmap images.
-- **scanpaths/** – Directory of generated scanpath visualizations.
-
----
+- The previous exploratory notebooks are still available under `data_analysis/`, `preprocessing/`, and `visualization/` for reference.
 
 ## Setup
 
@@ -112,3 +88,17 @@ This repository contains Jupyter notebooks and helper files for **processing and
 
 Each notebook can be executed independently to perform its step in the pipeline.  
 Run them within **Jupyter Notebook** or **JupyterLab**; outputs are written to the respective `processed/` subdirectories.
+
+---
+
+## Confirmatory analysis workflow
+
+1. **Generate metrics** – Ensure the processed fixation CSVs live under `fixations/` and labels are recorded in `labels_per_id.csv`. The new `analysis_pipeline` package will normalise per-participant metrics automatically.
+2. **Interactive GUI** – Launch the Streamlit interface:
+   ```bash
+   streamlit run analysis_pipeline/gui.py
+   ```
+   The app starts from the full dataset baseline, then lets you drill into single labels and label combinations, visualises metric deltas, displays PCA/k-means clustering, and runs confirmatory statistics with effect sizes.
+3. **Notebook workflow** – Open `notebooks/confirmatory_analysis_example.ipynb` to see the same steps scripted in Python for reproducible reports.
+
+The reusable functions allow you to compose additional scripts or dashboards without rewriting metric calculations, making it straightforward to test hypotheses on the existing dataset and future data collections.

--- a/analysis_pipeline/__init__.py
+++ b/analysis_pipeline/__init__.py
@@ -1,0 +1,33 @@
+"""High-level utilities for confirmatory eye-tracking analysis."""
+
+from .data_loading import (
+    build_metrics_table,
+    get_participant_ids,
+    load_labels,
+)
+from .hierarchy import (
+    build_hierarchical_summary,
+    compute_baseline,
+    compute_label_comparison,
+)
+from .clustering import (
+    compute_cluster_profiles,
+    run_kmeans_clustering,
+)
+from .statistics import (
+    run_confirmatory_tests,
+    summarize_pairwise_results,
+)
+
+__all__ = [
+    "build_metrics_table",
+    "get_participant_ids",
+    "load_labels",
+    "build_hierarchical_summary",
+    "compute_baseline",
+    "compute_label_comparison",
+    "compute_cluster_profiles",
+    "run_kmeans_clustering",
+    "run_confirmatory_tests",
+    "summarize_pairwise_results",
+]

--- a/analysis_pipeline/clustering.py
+++ b/analysis_pipeline/clustering.py
@@ -1,0 +1,95 @@
+"""Clustering helpers for label combinations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+from sklearn.cluster import KMeans
+from sklearn.decomposition import PCA
+from sklearn.preprocessing import StandardScaler
+
+from .hierarchy import compute_label_comparison
+
+
+@dataclass
+class ClusterOutput:
+    features: pd.DataFrame
+    scaled_features: np.ndarray
+    pca_model: Optional[PCA]
+    pca_components: Optional[pd.DataFrame]
+    assignments: Optional[pd.Series]
+    kmeans_model: Optional[KMeans]
+
+
+def run_kmeans_clustering(
+    features: pd.DataFrame,
+    *,
+    n_clusters: int,
+    random_state: int = 42,
+) -> KMeans:
+    scaler = StandardScaler()
+    scaled = scaler.fit_transform(features)
+    model = KMeans(n_clusters=n_clusters, n_init="auto", random_state=random_state)
+    model.fit(scaled)
+    return model
+
+
+def compute_cluster_profiles(
+    metrics_table: pd.DataFrame,
+    *,
+    metrics: Optional[Iterable[str]] = None,
+    n_components: int = 2,
+    n_clusters: Optional[int] = None,
+    random_state: int = 42,
+) -> ClusterOutput:
+    summary = compute_label_comparison(
+        metrics_table,
+        group_column="label_combo",
+        metrics=metrics,
+        baseline=None,
+        min_count=1,
+    )
+    if summary.summary.empty:
+        return ClusterOutput(
+            features=pd.DataFrame(),
+            scaled_features=np.empty((0, 0)),
+            pca_model=None,
+            pca_components=None,
+            assignments=None,
+            kmeans_model=None,
+        )
+
+    feature_columns = [column for column in summary.summary.columns if column.endswith("_norm")]
+    features = summary.summary[feature_columns]
+
+    scaler = StandardScaler()
+    scaled = scaler.fit_transform(features)
+
+    pca_model: Optional[PCA] = None
+    pca_components_df: Optional[pd.DataFrame] = None
+    if features.shape[1] >= n_components and n_components > 0:
+        pca_model = PCA(n_components=n_components, random_state=random_state)
+        components = pca_model.fit_transform(scaled)
+        pca_components_df = pd.DataFrame(
+            components,
+            index=features.index,
+            columns=[f"PC{i+1}" for i in range(components.shape[1])],
+        )
+
+    assignments: Optional[pd.Series] = None
+    kmeans_model: Optional[KMeans] = None
+    if n_clusters is not None and n_clusters > 1:
+        kmeans_model = KMeans(n_clusters=n_clusters, n_init="auto", random_state=random_state)
+        kmeans_model.fit(scaled)
+        assignments = pd.Series(kmeans_model.labels_, index=features.index, name="cluster")
+
+    return ClusterOutput(
+        features=features,
+        scaled_features=scaled,
+        pca_model=pca_model,
+        pca_components=pca_components_df,
+        assignments=assignments,
+        kmeans_model=kmeans_model,
+    )

--- a/analysis_pipeline/data_loading.py
+++ b/analysis_pipeline/data_loading.py
@@ -1,0 +1,125 @@
+"""Data ingestion helpers for confirmatory analysis."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .metrics import FixationMetricConfig, compute_fixation_metrics, load_fixation_table
+
+_LABEL_COLUMNS: List[str] = ["meme", "person", "politik", "ort", "text"]
+
+_FILENAME_PATTERN = re.compile(
+    r"^P(?P<participant>\d+)_id(?P<image>\d+)(?:_(?P<label>[A-Za-z0-9-]+))?_(?P<weights>[0-9]{5})?\.csv$"
+)
+
+
+@dataclass(frozen=True)
+class FixationRecord:
+    """Metadata extracted from a fixation file name."""
+
+    participant_id: str
+    image_id: int
+    label_hint: Optional[str]
+    weight_code: Optional[str]
+
+    @property
+    def label_from_filename(self) -> Optional[str]:
+        if self.label_hint:
+            return self.label_hint.replace("-", " ")
+        return None
+
+
+def parse_fixation_filename(filename: str) -> FixationRecord:
+    """Parse metadata encoded in a processed fixation file name."""
+
+    match = _FILENAME_PATTERN.match(Path(filename).name)
+    if not match:
+        raise ValueError(f"Cannot parse fixation filename: {filename}")
+
+    participant = match.group("participant")
+    image = match.group("image")
+    label = match.group("label")
+    weights = match.group("weights")
+
+    return FixationRecord(
+        participant_id=f"P{int(participant):03d}",
+        image_id=int(image),
+        label_hint=label,
+        weight_code=weights,
+    )
+
+
+def load_labels(labels_csv: Path) -> pd.DataFrame:
+    """Load the label assignment table and derive combination columns."""
+
+    labels = pd.read_csv(labels_csv)
+    labels["image_id"] = labels["image_id"].astype(int)
+    labels[_LABEL_COLUMNS] = labels[_LABEL_COLUMNS].fillna(0).astype(int)
+    labels["label_count"] = labels[_LABEL_COLUMNS].sum(axis=1)
+
+    def _combo(row: pd.Series) -> str:
+        active = [column for column in _LABEL_COLUMNS if row[column] > 0]
+        return " & ".join(active) if active else "unlabeled"
+
+    labels["label_combo"] = labels.apply(_combo, axis=1)
+    return labels
+
+
+def get_participant_ids(fixations_dir: Path) -> List[str]:
+    """Return sorted participant identifiers present in the fixation directory."""
+
+    participants = set()
+    for filepath in Path(fixations_dir).glob("*.csv"):
+        try:
+            record = parse_fixation_filename(filepath.name)
+        except ValueError:
+            continue
+        participants.add(record.participant_id)
+    return sorted(participants)
+
+
+def build_metrics_table(
+    fixations_dir: Path,
+    labels_csv: Path,
+    *,
+    metric_config: Optional[FixationMetricConfig] = None,
+) -> pd.DataFrame:
+    """Build a participant-level metric table joined with label metadata."""
+
+    labels = load_labels(labels_csv)
+    labels = labels.set_index("image_id")
+    records: List[Dict[str, float]] = []
+
+    for filepath in Path(fixations_dir).glob("*.csv"):
+        try:
+            record = parse_fixation_filename(filepath.name)
+        except ValueError:
+            continue
+
+        fixation_df = load_fixation_table(filepath)
+        metrics = compute_fixation_metrics(fixation_df, config=metric_config)
+
+        label_row = labels.loc[record.image_id] if record.image_id in labels.index else None
+        combined: Dict[str, float] = {
+            "filename": filepath.name,
+            "participant_id": record.participant_id,
+            "image_id": record.image_id,
+            "label_hint": record.label_from_filename,
+        }
+        combined.update(metrics)
+
+        if label_row is not None:
+            for column in label_row.index:
+                combined[column] = label_row[column]
+
+        records.append(combined)
+
+    metrics_table = pd.DataFrame.from_records(records)
+    if not metrics_table.empty:
+        metrics_table["participant_id"] = metrics_table["participant_id"].astype("category")
+        metrics_table["label_combo"] = metrics_table["label_combo"].astype("category")
+    return metrics_table

--- a/analysis_pipeline/gui.py
+++ b/analysis_pipeline/gui.py
@@ -1,0 +1,166 @@
+"""Streamlit application enabling interactive confirmatory analysis."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+from .clustering import compute_cluster_profiles
+from .data_loading import build_metrics_table
+from .hierarchy import SummaryResult, build_hierarchical_summary
+from .statistics import run_confirmatory_tests, summarize_pairwise_results
+from .visualization import (
+    metric_summary_frame,
+    plot_metric_delta,
+    plot_metric_distribution,
+    plot_metric_normalized,
+    plot_pca_scatter,
+)
+
+
+@st.cache_data(show_spinner="Loading metrics table...")
+def _load_metrics_cached(fixations_dir: str, labels_csv: str) -> pd.DataFrame:
+    return build_metrics_table(Path(fixations_dir), Path(labels_csv))
+
+
+def _show_summary(summary: SummaryResult, metric: str, *, show_delta: bool = True) -> None:
+    st.write(f"### {metric} summary")
+    st.dataframe(metric_summary_frame(summary, metric), use_container_width=True)
+    st.plotly_chart(
+        plot_metric_normalized(summary, metric),
+        use_container_width=True,
+    )
+    if show_delta:
+        try:
+            st.plotly_chart(
+                plot_metric_delta(summary, metric),
+                use_container_width=True,
+            )
+        except ValueError:
+            st.info("Delta plot requires a baseline; ensure the summary was built with one.")
+
+
+def _run_gui(metrics_table: pd.DataFrame) -> None:
+    st.title("Eye-tracking confirmatory analysis")
+
+    if metrics_table.empty:
+        st.warning("No fixation metrics available. Check your paths and preprocessing outputs.")
+        return
+
+    st.sidebar.header("Analysis options")
+    metric_columns = [
+        column
+        for column in [
+            "fixation_count",
+            "total_fixation_duration",
+            "mean_fixation_duration",
+            "scanpath_length",
+            "mean_saccade_length",
+            "avg_pupil_size",
+            "avg_norm_pupil_size",
+        ]
+        if column in metrics_table.columns
+    ]
+    selected_metric = st.sidebar.selectbox("Metric", metric_columns)
+
+    summary = build_hierarchical_summary(metrics_table, metrics=metric_columns)
+
+    st.write("## Baseline (All images)")
+    st.dataframe(summary["baseline"].summary, use_container_width=True)
+
+    level = st.sidebar.radio("Hierarchy level", ("Single labels", "Label combinations"))
+    if level == "Single labels":
+        summary_result = summary["single_labels"]
+    else:
+        summary_result = summary["label_combinations"]
+        available = summary_result.summary.index.tolist()
+        selected_labels = st.sidebar.multiselect(
+            "Filter label combinations",
+            options=available,
+            default=available,
+        )
+        if selected_labels:
+            summary_result = SummaryResult(
+                summary=summary_result.summary.loc[selected_labels],
+                metrics=summary_result.metrics,
+            )
+
+    _show_summary(summary_result, selected_metric, show_delta=True)
+
+    st.write("## Distribution by group")
+    group_column = "label_combo" if level == "Label combinations" else "labels_txt"
+    st.plotly_chart(
+        plot_metric_distribution(
+            metrics_table,
+            metric=selected_metric,
+            group_column=group_column,
+            title=f"Distribution of {selected_metric} by {group_column}",
+        ),
+        use_container_width=True,
+    )
+
+    st.write("## Clustering of label combinations")
+    cluster_k = st.sidebar.slider("Number of clusters", min_value=2, max_value=8, value=3)
+    cluster_output = compute_cluster_profiles(
+        metrics_table,
+        metrics=metric_columns,
+        n_components=2,
+        n_clusters=cluster_k,
+    )
+    if cluster_output.pca_components is not None:
+        st.plotly_chart(
+            plot_pca_scatter(cluster_output.pca_components, assignments=cluster_output.assignments),
+            use_container_width=True,
+        )
+        st.dataframe(cluster_output.features, use_container_width=True)
+    else:
+        st.info("PCA components could not be computed for the selected metrics.")
+
+    st.write("## Confirmatory statistics")
+    test_group_column = "label_combo" if level == "Label combinations" else "labels_txt"
+    stats_results = run_confirmatory_tests(
+        metrics_table,
+        group_column=test_group_column,
+        metrics=metric_columns,
+    )
+    if not stats_results:
+        st.info("Not enough observations per group for statistical tests.")
+    else:
+        for metric_name, result in stats_results.items():
+            st.subheader(metric_name)
+            anova_res = result.get("anova")
+            if anova_res:
+                eta_string = (
+                    f"{anova_res.effect_size:.3f}" if anova_res.effect_size is not None else "NA"
+                )
+                st.markdown(
+                    f"ANOVA: F={anova_res.statistic:.3f} (df={anova_res.df_between}, {anova_res.df_within}), "
+                    f"p={anova_res.pvalue:.3g}, eta²={eta_string}"
+                )
+            kruskal_res = result.get("kruskal")
+            if kruskal_res:
+                st.markdown(
+                    f"Kruskal-Wallis: H={kruskal_res.statistic:.3f}, p={kruskal_res.pvalue:.3g}"
+                )
+            pairwise_param = summarize_pairwise_results(result.get("pairwise_parametric", []))
+            if not pairwise_param.empty:
+                st.write("Parametric post-hoc tests")
+                st.dataframe(pairwise_param, use_container_width=True)
+            pairwise_nonparam = summarize_pairwise_results(result.get("pairwise_nonparametric", []))
+            if not pairwise_nonparam.empty:
+                st.write("Non-parametric post-hoc tests")
+                st.dataframe(pairwise_nonparam, use_container_width=True)
+
+
+def main(
+    *,
+    fixations_dir: str = "fixations",
+    labels_csv: str = "labels_per_id.csv",
+) -> None:
+    metrics_table = _load_metrics_cached(fixations_dir, labels_csv)
+    _run_gui(metrics_table)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis_pipeline/hierarchy.py
+++ b/analysis_pipeline/hierarchy.py
@@ -1,0 +1,166 @@
+"""Hierarchical summaries of metrics across label levels."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+
+_LABEL_COLUMNS: List[str] = ["meme", "person", "politik", "ort", "text"]
+_DEFAULT_METRIC_COLUMNS: List[str] = [
+    "fixation_count",
+    "total_fixation_duration",
+    "mean_fixation_duration",
+    "scanpath_length",
+    "mean_saccade_length",
+    "avg_pupil_size",
+    "avg_norm_pupil_size",
+]
+
+
+@dataclass(frozen=True)
+class SummaryResult:
+    """Container bundling summary statistics for a label grouping."""
+
+    summary: pd.DataFrame
+    metrics: List[str]
+
+    def difference_columns(self) -> List[str]:
+        return [column for column in self.summary.columns if column.endswith("_delta")]
+
+
+def _participant_count(metrics_table: pd.DataFrame) -> int:
+    return int(metrics_table["participant_id"].nunique())
+
+
+def _aggregate_subset(
+    subset: pd.DataFrame,
+    metrics: Iterable[str],
+    participant_total: int,
+) -> Dict[str, float]:
+    if subset.empty:
+        result: Dict[str, float] = {f"{metric}_mean": np.nan for metric in metrics}
+        result.update({f"{metric}_std": np.nan for metric in metrics})
+        result.update({f"{metric}_norm": np.nan for metric in metrics})
+        result["participants_observed"] = 0
+        result["images_observed"] = 0
+        return result
+
+    participant_group = (
+        subset.groupby("participant_id", observed=True)[list(metrics)].mean()
+    )
+
+    result: Dict[str, float] = {}
+    for metric in metrics:
+        values = participant_group[metric]
+        result[f"{metric}_mean"] = float(values.mean())
+        result[f"{metric}_std"] = float(values.std(ddof=1)) if len(values) > 1 else np.nan
+        result[f"{metric}_norm"] = float(values.sum() / participant_total)
+    result["participants_observed"] = int(participant_group.shape[0])
+    result["images_observed"] = int(subset["image_id"].nunique())
+    return result
+
+
+def compute_baseline(
+    metrics_table: pd.DataFrame,
+    *,
+    metrics: Optional[Iterable[str]] = None,
+) -> pd.Series:
+    metrics = list(metrics or _DEFAULT_METRIC_COLUMNS)
+    participant_total = _participant_count(metrics_table)
+    summary = _aggregate_subset(metrics_table, metrics, participant_total)
+    return pd.Series(summary)
+
+
+def _attach_differences(
+    summary_df: pd.DataFrame,
+    baseline: Mapping[str, float],
+    metrics: Iterable[str],
+) -> pd.DataFrame:
+    df = summary_df.copy()
+    for metric in metrics:
+        baseline_value = baseline.get(f"{metric}_norm", np.nan)
+        if np.isnan(baseline_value) or baseline_value == 0:
+            df[f"{metric}_delta"] = np.nan
+            df[f"{metric}_delta_pct"] = np.nan
+            continue
+        df[f"{metric}_delta"] = df[f"{metric}_norm"] - baseline_value
+        df[f"{metric}_delta_pct"] = df[f"{metric}_delta"] / baseline_value
+    return df
+
+
+def compute_label_comparison(
+    metrics_table: pd.DataFrame,
+    *,
+    group_column: str,
+    metrics: Optional[Iterable[str]] = None,
+    baseline: Optional[Mapping[str, float]] = None,
+    min_count: int = 1,
+) -> SummaryResult:
+    metrics = list(metrics or _DEFAULT_METRIC_COLUMNS)
+    participant_total = _participant_count(metrics_table)
+
+    summaries: List[Dict[str, float]] = []
+    labels: List[str] = []
+
+    for label_value, subset in metrics_table.groupby(group_column, observed=True):
+        subset_stats = _aggregate_subset(subset, metrics, participant_total)
+        if subset_stats["participants_observed"] < min_count:
+            continue
+        subset_stats[group_column] = label_value
+        summaries.append(subset_stats)
+        labels.append(label_value)
+
+    summary_df = pd.DataFrame(summaries)
+    if summary_df.empty:
+        return SummaryResult(summary=pd.DataFrame(), metrics=metrics)
+
+    if baseline is not None:
+        summary_df = _attach_differences(summary_df, baseline, metrics)
+
+    summary_df = summary_df.set_index(group_column).sort_index()
+    return SummaryResult(summary=summary_df, metrics=metrics)
+
+
+def _single_label_table(
+    metrics_table: pd.DataFrame,
+    metrics: Iterable[str],
+    baseline: Optional[Mapping[str, float]],
+) -> SummaryResult:
+    participant_total = _participant_count(metrics_table)
+    rows: List[Dict[str, float]] = []
+    for label in _LABEL_COLUMNS:
+        subset = metrics_table.loc[metrics_table[label] == 1]
+        stats = _aggregate_subset(subset, metrics, participant_total)
+        stats["label"] = label
+        rows.append(stats)
+    df = pd.DataFrame(rows)
+    if baseline is not None:
+        df = _attach_differences(df, baseline, metrics)
+    df = df.set_index("label")
+    return SummaryResult(summary=df, metrics=list(metrics))
+
+
+def build_hierarchical_summary(
+    metrics_table: pd.DataFrame,
+    *,
+    metrics: Optional[Iterable[str]] = None,
+) -> Dict[str, SummaryResult]:
+    metrics = list(metrics or _DEFAULT_METRIC_COLUMNS)
+    baseline = compute_baseline(metrics_table, metrics=metrics)
+    single_labels = _single_label_table(metrics_table, metrics, baseline)
+    combinations = compute_label_comparison(
+        metrics_table,
+        group_column="label_combo",
+        metrics=metrics,
+        baseline=baseline,
+        min_count=1,
+    )
+    baseline_df = baseline.to_frame().T
+    baseline_df.index = ["All"]
+    return {
+        "baseline": SummaryResult(summary=baseline_df, metrics=metrics),
+        "single_labels": single_labels,
+        "label_combinations": combinations,
+    }

--- a/analysis_pipeline/metrics.py
+++ b/analysis_pipeline/metrics.py
@@ -1,0 +1,83 @@
+"""Metric computation utilities for fixation-level data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class FixationMetricConfig:
+    """Configuration for metric computation."""
+
+    min_required_fixations: int = 1
+    coordinate_columns: Iterable[str] = ("x", "y")
+    duration_column: str = "duration"
+    pupil_size_column: str = "avg_pupil_size"
+    pupil_norm_column: str = "pupil_size_norm"
+
+
+def _scanpath_length(values: pd.DataFrame, coordinate_columns: Iterable[str]) -> float:
+    coords = values.loc[:, list(coordinate_columns)].to_numpy(dtype=float, copy=True)
+    if len(coords) < 2:
+        return 0.0
+    deltas = np.diff(coords, axis=0)
+    distances = np.linalg.norm(deltas, axis=1)
+    return float(distances.sum())
+
+
+def compute_fixation_metrics(
+    fixations: pd.DataFrame,
+    config: Optional[FixationMetricConfig] = None,
+) -> Dict[str, float]:
+    """Compute a suite of metrics for a fixation table."""
+
+    if config is None:
+        config = FixationMetricConfig()
+
+    if fixations.empty:
+        return {
+            "fixation_count": 0.0,
+            "total_fixation_duration": 0.0,
+            "mean_fixation_duration": np.nan,
+            "scanpath_length": 0.0,
+            "mean_saccade_length": np.nan,
+            "avg_pupil_size": np.nan,
+            "avg_norm_pupil_size": np.nan,
+            "std_norm_pupil_size": np.nan,
+        }
+
+    fixation_count = float(len(fixations))
+    durations = fixations.get(config.duration_column)
+    total_duration = float(durations.sum()) if durations is not None else np.nan
+    mean_duration = float(durations.mean()) if durations is not None else np.nan
+
+    scan_length = _scanpath_length(fixations, config.coordinate_columns)
+    mean_saccade = float(scan_length / max(fixation_count - 1.0, 1.0))
+
+    pupil = fixations.get(config.pupil_size_column)
+    pupil_norm = fixations.get(config.pupil_norm_column)
+
+    metrics: Dict[str, float] = {
+        "fixation_count": fixation_count,
+        "total_fixation_duration": total_duration,
+        "mean_fixation_duration": mean_duration,
+        "scanpath_length": scan_length,
+        "mean_saccade_length": mean_saccade,
+        "avg_pupil_size": float(pupil.mean()) if pupil is not None else np.nan,
+        "avg_norm_pupil_size": float(pupil_norm.mean()) if pupil_norm is not None else np.nan,
+        "std_norm_pupil_size": float(pupil_norm.std(ddof=1)) if pupil_norm is not None else np.nan,
+    }
+
+    return metrics
+
+
+def load_fixation_table(filepath: Path) -> pd.DataFrame:
+    """Load a fixation CSV produced by the preprocessing step."""
+
+    df = pd.read_csv(filepath)
+    df.columns = [column.strip() for column in df.columns]
+    return df

--- a/analysis_pipeline/statistics.py
+++ b/analysis_pipeline/statistics.py
@@ -1,0 +1,209 @@
+"""Statistical testing utilities for confirmatory analyses."""
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+_DEFAULT_METRICS: List[str] = [
+    "fixation_count",
+    "total_fixation_duration",
+    "scanpath_length",
+    "mean_fixation_duration",
+    "avg_pupil_size",
+    "avg_norm_pupil_size",
+]
+
+
+@dataclass(frozen=True)
+class TestResult:
+    statistic: float
+    pvalue: float
+    effect_size: Optional[float]
+    test_type: str
+    df_between: Optional[int] = None
+    df_within: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class PairwiseResult:
+    group_a: str
+    group_b: str
+    statistic: float
+    pvalue_raw: float
+    pvalue_adj: float
+    effect_size: Optional[float]
+    method: str
+
+
+def _cohen_d(sample_a: np.ndarray, sample_b: np.ndarray) -> Optional[float]:
+    if len(sample_a) < 2 or len(sample_b) < 2:
+        return None
+    mean_a, mean_b = sample_a.mean(), sample_b.mean()
+    var_a, var_b = sample_a.var(ddof=1), sample_b.var(ddof=1)
+    pooled = ((len(sample_a) - 1) * var_a + (len(sample_b) - 1) * var_b) / (
+        len(sample_a) + len(sample_b) - 2
+    )
+    if pooled <= 0:
+        return None
+    return float((mean_a - mean_b) / np.sqrt(pooled))
+
+
+def _rank_biserial(u_stat: float, n_a: int, n_b: int) -> float:
+    return 1 - (2 * u_stat) / (n_a * n_b)
+
+
+def _prepare_samples(
+    metrics_table: pd.DataFrame,
+    group_column: str,
+    metric: str,
+) -> Dict[str, np.ndarray]:
+    samples: Dict[str, np.ndarray] = {}
+    for group_value, subset in metrics_table.groupby(group_column, observed=True):
+        values = subset[metric].dropna().to_numpy()
+        if len(values) > 0:
+            samples[str(group_value)] = values
+    return samples
+
+
+def _anova(samples: Mapping[str, np.ndarray]) -> Optional[TestResult]:
+    if len(samples) < 2:
+        return None
+    arrays = list(samples.values())
+    statistic, pvalue = stats.f_oneway(*arrays)
+    n_total = sum(len(sample) for sample in arrays)
+    df_between = len(arrays) - 1
+    df_within = n_total - len(arrays)
+    eta_sq = (statistic * df_between) / (statistic * df_between + df_within) if df_within > 0 else None
+    return TestResult(
+        statistic=float(statistic),
+        pvalue=float(pvalue),
+        effect_size=float(eta_sq) if eta_sq is not None else None,
+        test_type="ANOVA",
+        df_between=df_between,
+        df_within=df_within,
+    )
+
+
+def _kruskal(samples: Mapping[str, np.ndarray]) -> Optional[TestResult]:
+    if len(samples) < 2:
+        return None
+    statistic, pvalue = stats.kruskal(*samples.values())
+    return TestResult(
+        statistic=float(statistic),
+        pvalue=float(pvalue),
+        effect_size=None,
+        test_type="Kruskal-Wallis",
+    )
+
+
+def _bonferroni(pvalues: List[float]) -> List[float]:
+    correction = len(pvalues)
+    return [min(p * correction, 1.0) for p in pvalues]
+
+
+def _pairwise_tests(
+    samples: Mapping[str, np.ndarray],
+    *,
+    method: str,
+    correction: str = "bonferroni",
+) -> List[PairwiseResult]:
+    pairs = list(itertools.combinations(samples.items(), 2))
+    raw_pvalues: List[float] = []
+    base_results: List[Tuple[str, str, float, float, Optional[float]]] = []
+
+    for (label_a, sample_a), (label_b, sample_b) in pairs:
+        if method == "parametric":
+            statistic, pvalue = stats.ttest_ind(sample_a, sample_b, equal_var=False)
+            effect = _cohen_d(sample_a, sample_b)
+        else:
+            statistic, pvalue = stats.mannwhitneyu(sample_a, sample_b, alternative="two-sided")
+            effect = _rank_biserial(statistic, len(sample_a), len(sample_b))
+        raw_pvalues.append(float(pvalue))
+        base_results.append((str(label_a), str(label_b), float(statistic), float(pvalue), effect))
+
+    if not base_results:
+        return []
+
+    if correction.lower() == "bonferroni":
+        adjusted = _bonferroni(raw_pvalues)
+    else:
+        adjusted = raw_pvalues
+
+    pairwise_results: List[PairwiseResult] = []
+    for (label_a, label_b, statistic, pvalue, effect), adj in zip(base_results, adjusted):
+        pairwise_results.append(
+            PairwiseResult(
+                group_a=label_a,
+                group_b=label_b,
+                statistic=statistic,
+                pvalue_raw=pvalue,
+                pvalue_adj=adj,
+                effect_size=effect,
+                method="parametric" if method == "parametric" else "nonparametric",
+            )
+        )
+    return pairwise_results
+
+
+def run_confirmatory_tests(
+    metrics_table: pd.DataFrame,
+    *,
+    group_column: str,
+    metrics: Optional[Iterable[str]] = None,
+    alpha: float = 0.05,
+    correction: str = "bonferroni",
+) -> Dict[str, Dict[str, object]]:
+    metrics = list(metrics or _DEFAULT_METRICS)
+    results: Dict[str, Dict[str, object]] = {}
+
+    for metric in metrics:
+        samples = _prepare_samples(metrics_table, group_column, metric)
+        if len(samples) < 2:
+            continue
+        anova_res = _anova(samples)
+        kruskal_res = _kruskal(samples)
+        parametric_pairs = _pairwise_tests(samples, method="parametric", correction=correction)
+        nonparam_pairs = _pairwise_tests(samples, method="nonparametric", correction=correction)
+
+        results[metric] = {
+            "anova": anova_res,
+            "kruskal": kruskal_res,
+            "pairwise_parametric": parametric_pairs,
+            "pairwise_nonparametric": nonparam_pairs,
+            "descriptives": {
+                label: {
+                    "n": int(len(values)),
+                    "mean": float(values.mean()),
+                    "std": float(values.std(ddof=1)) if len(values) > 1 else np.nan,
+                }
+                for label, values in samples.items()
+            },
+        }
+    return results
+
+
+def summarize_pairwise_results(
+    pairwise: Iterable[PairwiseResult],
+    *,
+    alpha: float = 0.05,
+) -> pd.DataFrame:
+    rows = []
+    for result in pairwise:
+        rows.append(
+            {
+                "group_a": result.group_a,
+                "group_b": result.group_b,
+                "statistic": result.statistic,
+                "pvalue_raw": result.pvalue_raw,
+                "pvalue_adj": result.pvalue_adj,
+                "effect_size": result.effect_size,
+                "method": result.method,
+                "significant": result.pvalue_adj < alpha,
+            }
+        )
+    return pd.DataFrame(rows)

--- a/analysis_pipeline/visualization.py
+++ b/analysis_pipeline/visualization.py
@@ -1,0 +1,105 @@
+"""Visualization primitives for the confirmatory analysis workflow."""
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+from .hierarchy import SummaryResult
+
+
+def metric_summary_frame(summary: SummaryResult, metric: str) -> pd.DataFrame:
+    """Return a tidy dataframe with statistics for a single metric."""
+
+    df = summary.summary.copy()
+    columns = [
+        f"{metric}_mean",
+        f"{metric}_std",
+        f"{metric}_norm",
+        f"{metric}_delta",
+        f"{metric}_delta_pct",
+    ]
+    available = [column for column in columns if column in df.columns]
+    tidy = df[available].rename(
+        columns={
+            f"{metric}_mean": "mean",
+            f"{metric}_std": "std",
+            f"{metric}_norm": "normalized",
+            f"{metric}_delta": "delta",
+            f"{metric}_delta_pct": "delta_pct",
+        }
+    )
+    tidy["group"] = tidy.index
+    return tidy.reset_index(drop=True)
+
+
+def plot_metric_normalized(summary: SummaryResult, metric: str, *, title: Optional[str] = None) -> go.Figure:
+    data = metric_summary_frame(summary, metric)
+    fig = px.bar(
+        data,
+        x="group",
+        y="normalized",
+        error_y="std" if "std" in data else None,
+        title=title or f"Normalized {metric} by group",
+        labels={"normalized": "Normalized value", "group": "Group"},
+    )
+    fig.update_layout(xaxis_tickangle=-45)
+    return fig
+
+
+def plot_metric_delta(summary: SummaryResult, metric: str, *, title: Optional[str] = None) -> go.Figure:
+    data = metric_summary_frame(summary, metric)
+    if "delta" not in data:
+        raise ValueError("Summary is missing delta information; provide a baseline when building it.")
+    fig = px.bar(
+        data,
+        x="group",
+        y="delta",
+        title=title or f"Deviation from baseline for {metric}",
+        labels={"delta": "Delta (absolute)", "group": "Group"},
+        color="delta",
+        color_continuous_scale="RdBu",
+    )
+    fig.update_layout(xaxis_tickangle=-45)
+    return fig
+
+
+def plot_pca_scatter(
+    pca_components: pd.DataFrame,
+    *,
+    assignments: Optional[pd.Series] = None,
+    title: str = "PCA of metric profiles",
+) -> go.Figure:
+    df = pca_components.copy()
+    if assignments is not None:
+        df["cluster"] = assignments
+    fig = px.scatter(
+        df,
+        x="PC1",
+        y="PC2",
+        color="cluster" if "cluster" in df else None,
+        text=df.index,
+        title=title,
+    )
+    fig.update_traces(textposition="top center")
+    return fig
+
+
+def plot_metric_distribution(
+    metrics_table: pd.DataFrame,
+    *,
+    metric: str,
+    group_column: str,
+    title: Optional[str] = None,
+) -> go.Figure:
+    fig = px.box(
+        metrics_table,
+        x=group_column,
+        y=metric,
+        points="all",
+        title=title or f"Distribution of {metric} by {group_column}",
+    )
+    fig.update_layout(xaxis_tickangle=-45)
+    return fig

--- a/notebooks/confirmatory_analysis_example.ipynb
+++ b/notebooks/confirmatory_analysis_example.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Confirmatory analysis walkthrough\n",
+    "\n",
+    "This notebook demonstrates how to move from exploratory calculations to a confirmatory analysis workflow using the new reusable modules."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from analysis_pipeline.data_loading import build_metrics_table\n",
+    "from analysis_pipeline.hierarchy import build_hierarchical_summary\n",
+    "from analysis_pipeline.statistics import run_confirmatory_tests, summarize_pairwise_results\n",
+    "from analysis_pipeline.clustering import compute_cluster_profiles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load metrics and labels\n",
+    "\n",
+    "Metrics are aggregated per participant and image, then normalised by the full participant pool (49 viewers)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FIXATIONS_DIR = Path('fixations')\n",
+    "LABELS_CSV = Path('labels_per_id.csv')\n",
+    "\n",
+    "metrics_table = build_metrics_table(FIXATIONS_DIR, LABELS_CSV)\n",
+    "metrics_table.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hierarchical summaries\n",
+    "\n",
+    "Start from all images, then inspect single labels and label combinations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summary = build_hierarchical_summary(metrics_table)\n",
+    "baseline = summary['baseline'].summary\n",
+    "single_labels = summary['single_labels'].summary\n",
+    "label_combinations = summary['label_combinations'].summary\n",
+    "\n",
+    "baseline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "label_combinations.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Confirmatory statistics\n",
+    "\n",
+    "Run ANOVA/Kruskal-Wallis tests and inspect post-hoc comparisons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tests = run_confirmatory_tests(metrics_table, group_column='label_combo')\n",
+    "tests['fixation_count']['anova']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pairwise = summarize_pairwise_results(tests['fixation_count']['pairwise_parametric'])\n",
+    "pairwise.sort_values('pvalue_adj').head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clustering\n",
+    "\n",
+    "Use PCA + k-means to see whether label combinations form metric-based clusters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster_output = compute_cluster_profiles(metrics_table, n_components=2, n_clusters=3)\n",
+    "cluster_output.pca_components.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,8 @@ threadpoolctl==3.6.0
 # Visualization
 matplotlib==3.10.5
 seaborn==0.13.2
+plotly==5.24.1
+streamlit==1.41.1
 contourpy==1.3.3
 cycler==0.12.1
 fonttools==4.59.1


### PR DESCRIPTION
## Summary
- add a reusable `analysis_pipeline` package that loads metrics, computes hierarchical summaries, clustering inputs and confirmatory statistics
- ship a Streamlit GUI plus Plotly visualisations so label selections surface baseline deltas, clustering and statistical tests interactively
- document the confirmatory workflow, add an example notebook, and declare new Plotly/Streamlit dependencies

## Testing
- python -m compileall analysis_pipeline

------
https://chatgpt.com/codex/tasks/task_e_68cb12f95828832b993b01dac460f60b